### PR TITLE
Log model usage and set default persona

### DIFF
--- a/welcome/programming_helper_chatbot.py
+++ b/welcome/programming_helper_chatbot.py
@@ -262,14 +262,16 @@ def programming_helper_send_message(request):  # noqa: C901
     if local == "ollama":
         if requests is None:
             return JsonResponse({"error": "requests library not installed"}, status=500)
+        model = OLLAMA_QWEN_14
         payload = {
-            "model": OLLAMA_QWEN_14,
+            "model": model,
             "prompt": prompt_for_ollama,
             "system": combined_system,
             "stream": False,
             "think": False,
             "hidethinking": True,
         }
+        print(f"Model in use: {model}")
         try:
             resp = requests.post("http://localhost:11434/api/generate", json=payload, timeout=45)
             resp.raise_for_status()
@@ -289,6 +291,7 @@ def programming_helper_send_message(request):  # noqa: C901
             else MISTRAL_MODEL_L if mode == "large"
             else MISTRAL_MODEL_R
         )
+        print(f"Model in use: {model}")
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -325,6 +328,7 @@ def programming_helper_send_message(request):  # noqa: C901
         else:
             model_name = OPENAI_MODEL_L
             reasoning = None
+        print(f"Model in use: {model_name}")
         try:
             resp = client.responses.create(
                 model=model_name,
@@ -351,6 +355,7 @@ def programming_helper_send_message(request):  # noqa: C901
             model_name = OPENROUTER_MODEL_M
         else:
             model_name = OPENROUTER_MODEL_L
+        print(f"Model in use: {model_name}")
 
         body = {
             "model": model_name,

--- a/welcome/templates/welcome/chat.html
+++ b/welcome/templates/welcome/chat.html
@@ -16,6 +16,7 @@
         <label for="persona-select">Persona:</label>
         <select id="persona-select"></select>
     </div>
+    <div id="persona-error" style="color: red;"></div>
     <div>
         <label for="api-select">API:</label>
         <select id="api-select">
@@ -34,12 +35,20 @@
         const res = await fetch('/api/personas/');
         const data = await res.json();
         const select = document.getElementById('persona-select');
+        let coderFound = false;
         data.personas.forEach(p => {
             const opt = document.createElement('option');
             opt.value = p.id;
             opt.textContent = p.nome + ' v' + p.versione;
+            if (p.nome === 'Coder') {
+                opt.selected = true;
+                coderFound = true;
+            }
             select.appendChild(opt);
         });
+        if (!coderFound) {
+            document.getElementById('persona-error').textContent = 'Persona Coder non trovata';
+        }
     }
 
     async function sendMessage() {

--- a/welcome/templates/welcome/index.html
+++ b/welcome/templates/welcome/index.html
@@ -9,6 +9,7 @@
     <input id="name-input" type="text" placeholder="Inserisci il tuo nome" />
     <button id="ok-btn">OK</button>
     <button id="admin-btn" onclick="window.location.href='/admin/'">Admin</button>
+    <button id="chat-btn" onclick="window.location.href='/chat/'">Chat</button>
 
     <script>
     document.getElementById('ok-btn').addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- log selected model for each provider in programming helper endpoint
- auto-select the Coder persona and show an error if missing
- add navigation button on index to reach chat page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689a27d85f508324885f7ac6b1976099