### PR TITLE
Add model size selector for chat providers

### DIFF
--- a/welcome/templates/welcome/chat.html
+++ b/welcome/templates/welcome/chat.html
@@ -26,6 +26,15 @@
             <option value="openrouter">OpenRouter</option>
         </select>
     </div>
+    <div>
+        <label for="size-select">Size:</label>
+        <select id="size-select">
+            <option value="s">S</option>
+            <option value="m" selected>M</option>
+            <option value="l">L</option>
+            <option value="r">R</option>
+        </select>
+    </div>
     <div id="chat-box"></div>
     <textarea id="message-input" placeholder="Scrivi un messaggio"></textarea>
     <button id="send-btn">Invia</button>
@@ -64,11 +73,12 @@
         const msg = document.getElementById('message-input').value;
         const personaId = document.getElementById('persona-select').value;
         const api = document.getElementById('api-select').value;
+        const size = document.getElementById('size-select').value;
         if (!msg) return;
         const chatBox = document.getElementById('chat-box');
         chatBox.innerHTML += `<div class="user">Tu: ${msg}</div>`;
         document.getElementById('message-input').value = '';
-        const payload = { message: msg, local: api, persona_id: personaId };
+        const payload = { message: msg, local: api, size: size, persona_id: personaId };
         const res = await fetch('/api/programming_helper/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- add `size` parameter (S/M/L/R) to select model size per provider
- update chat UI to expose size dropdown and send size in requests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689a62ab54108324b4188054d44a9310