### PR TITLE
Default RP to OpenRouter L and fetch role-play prompt from Persona

### DIFF
--- a/welcome/templates/welcome/chat.html
+++ b/welcome/templates/welcome/chat.html
@@ -111,6 +111,13 @@
         logDiv.style.display = logDiv.style.display === 'none' ? 'block' : 'none';
     });
 
+    document.getElementById('rp-checkbox').addEventListener('change', function() {
+        if (this.checked) {
+            document.getElementById('api-select').value = 'openrouter';
+            document.getElementById('size-select').value = 'l';
+        }
+    });
+
     const messageInput = document.getElementById('message-input');
     messageInput.addEventListener('keydown', function(e) {
         if (e.key === 'Enter' && !e.shiftKey) {


### PR DESCRIPTION
## Summary
- Default role-play sessions to OpenRouter provider with large model
- Pull role-play system prompt from `RPPrompt` Persona instead of hardcoded string
- Auto-select OpenRouter L when RP checkbox is checked in chat UI

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689a6e4d2d84832484a73c68ce7f1aff