### PR TITLE
Add English persona toggle

### DIFF
--- a/welcome/chatbot_utils.py
+++ b/welcome/chatbot_utils.py
@@ -32,7 +32,10 @@ def _conversation_dump(character: str | None) -> Dict[str, List[Dict[str, str]]]
 
 def personas_list(request):
     master_mode = request.GET.get("master") == "true"
+    inglese_param = request.GET.get("inglese")
     qs = Persona.objects.all()
+    if inglese_param is not None:
+        qs = qs.filter(inglese=inglese_param.lower() == "true")
     if not master_mode:
         qs = qs.filter(ristretto=False)
     data = [

--- a/welcome/templates/welcome/chat.html
+++ b/welcome/templates/welcome/chat.html
@@ -19,6 +19,9 @@
     <div>
         <label><input type="checkbox" id="rp-checkbox" />RP</label>
     </div>
+    <div>
+        <label><input type="checkbox" id="english-checkbox" />English</label>
+    </div>
     <div id="persona-error" style="color: red;"></div>
     <div>
         <label for="api-select">API:</label>
@@ -46,9 +49,11 @@
 
     <script>
     async function loadPersonas() {
-        const res = await fetch('/api/personas/');
+        const english = document.getElementById('english-checkbox').checked;
+        const res = await fetch(`/api/personas/?inglese=${english}`);
         const data = await res.json();
         const select = document.getElementById('persona-select');
+        select.innerHTML = '';
         let coderFound = false;
         data.personas.forEach(p => {
             const opt = document.createElement('option');
@@ -60,8 +65,11 @@
             }
             select.appendChild(opt);
         });
+        const errDiv = document.getElementById('persona-error');
         if (!coderFound) {
-            document.getElementById('persona-error').textContent = 'Persona Coder non trovata';
+            errDiv.textContent = 'Persona Coder non trovata';
+        } else {
+            errDiv.textContent = '';
         }
     }
 
@@ -124,6 +132,7 @@
             document.getElementById('size-select').value = 'l';
         }
     });
+    document.getElementById('english-checkbox').addEventListener('change', loadPersonas);
     loadPersonas();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add inglese filter for persona list endpoint
- add English checkbox and reload logic in chat page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b2aafa3888324bab58ccc09417b4e